### PR TITLE
feat: re-render ListView after sort

### DIFF
--- a/admin/src/components/SortModal/index.js
+++ b/admin/src/components/SortModal/index.js
@@ -1,154 +1,219 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect } from "react";
 
-import axiosInstance from '../../utils/axiosInstance';
+import { useDispatch } from "react-redux";
+import {
+	getData,
+	getDataSucceeded,
+} from "@strapi/admin/admin/src/content-manager/pages/ListView/actions";
 
-import { SortableContainer, SortableElement } from 'react-sortable-hoc';
+import axiosInstance from "../../utils/axiosInstance";
 
-import { SimpleMenu, MenuItem } from '@strapi/design-system/SimpleMenu';
-import { IconButton } from '@strapi/design-system/IconButton';
-import { Icon } from '@strapi/design-system/Icon';
-import Drag from '@strapi/icons/Drag';
-import Layer from '@strapi/icons/Layer';
-import { arrayMoveImmutable } from 'array-move';
+import { SortableContainer, SortableElement } from "react-sortable-hoc";
+
+import { SimpleMenu, MenuItem } from "@strapi/design-system/SimpleMenu";
+import { IconButton } from "@strapi/design-system/IconButton";
+import { Icon } from "@strapi/design-system/Icon";
+import Drag from "@strapi/icons/Drag";
+import Layer from "@strapi/icons/Layer";
+import { arrayMoveImmutable } from "array-move";
+
+import { useQueryParams } from "../../utils/useQueryParams";
+
+const DEFAULT_SORT_MENU_PAGE_SIZE = 10;
 
 const SortModal = () => {
+	const [active, setActive] = useState(false);
+	const [data, setData] = useState([]);
+	const [currentPage, setCurrentPage] = useState(1);
+	const [pageSize, setPageSize] = useState(DEFAULT_SORT_MENU_PAGE_SIZE);
+	const [pagination, setPagination] = useState();
+	const [status, setStatus] = useState("loading");
+	const [settings, setSettings] = useState();
 
-  const [active, setActive] = useState(false);
-  const [data, setData] = useState([]);
-  const [status, setStatus] = useState('loading');
-  const [settings, setSettings] = useState();
+	// TODO: Refactor get queryParams to hook
+	const [params] = useQueryParams();
 
-  // Shorten string to prevent line break
-  const shortenString = (string) => {
-    if (string.length > 40) {
-      return string.substring(0, 37) + "..."
-    }
-    return string
-  }
+	const dispatch = useDispatch();
 
-  // Fetch settings from configuration
-  const fetchSettings = async () => {
-    try {
-      const { data } = await axiosInstance.get(`/drag-drop-content-types/settings`);
-      setSettings(data.body);
-    } catch (e) {
-      console.log(e);
-    }
-  };
+	const refetchEntries = React.useCallback(
+		() => dispatch(getData()),
+		[dispatch]
+	);
 
-  // Check database if the desired fields are available
-  // TODO: check field integrity 
-  const initializeContentType = async () => {
-    try {
-      if (settings) {
-        const { data } = await axiosInstance.get(
-          `/content-manager/collection-types/${contentTypePath}?sort=rank:asc`
-        );
-        if (data.results.length > 0 && !!toString(data.results[0][settings.rank]) && !!data.results[0][settings.title]) {
-          setActive(true);
-        }
-      }
-    } catch (e) {
-      console.log(e);
-      setStatus('error');
-    }
-  }
+	const refetchEntriesSucceeded = React.useCallback(
+		(pagination, newData) =>
+			dispatch(getDataSucceeded(pagination, newData)),
+		[dispatch, pagination, data]
+	);
 
-  // Fetch data from the database via get request
-  const fetchContentType = async () => {
-    try {
-      const { data } = await axiosInstance.get(
-        `/content-manager/collection-types/${contentTypePath}?sort=rank:asc&locale=${locale}`
-      );
-      setStatus('success');
-      setData(data.results);
-    } catch (e) {
-      console.log(e);
-      setStatus('error');
-    }
-  };
+	// Shorten string to prevent line break
+	const shortenString = (string) => {
+		if (string.length > 40) {
+			return string.substring(0, 37) + "...";
+		}
+		return string;
+	};
 
-  // Update all ranks via put request.
-  const updateContentType = async ({ oldIndex, newIndex }) => {
-    try {
-      // Increase performance by breaking loop after last element having a rank change is updated
-      const sortedList = arrayMoveImmutable(data, oldIndex, newIndex);
-      let rankHasChanged = false
-      // Iterate over all results and append them to the list
-      for (let i = 0; i < sortedList.length; i++) {
-        // Only update changed values
-        if (sortedList[i].id != data[i].id) {
-          // Update rank via put request
-          await axiosInstance.put(`/drag-drop-content-types/sort-update/${sortedList[i].id}`, {
-            contentType: contentTypePath,
-            rank: i,
-          });
-          rankHasChanged = true;
-        } else if (rankHasChanged) {
-          break;
-        }
-      }
-      //set new sorted data (refresh UI list component)
-      setData(sortedList);
-      setStatus('success');
-    } catch (e) {
-      console.log(e);
-      setStatus('error');
-    }
-  };
+	// Fetch settings from configuration
+	const fetchSettings = async () => {
+		try {
+			const { data } = await axiosInstance.get(
+				`/drag-drop-content-types/settings`
+			);
+			setSettings(data.body);
+		} catch (e) {
+			console.log(e);
+		}
+	};
 
+	// Check database if the desired fields are available
+	// TODO: check field integrity
+	const initializeContentType = async () => {
+		try {
+			if (settings) {
+				const { data } = await axiosInstance.get(
+					`/content-manager/collection-types/${contentTypePath}?sort=rank:asc&page=${currentPage}&pageSize=${pageSize}&locale=${locale}`
+				);
+				if (
+					data.results.length > 0 &&
+					!!toString(data.results[0][settings.rank]) &&
+					!!data.results[0][settings.title]
+				) {
+					setActive(true);
+				}
+			}
+		} catch (e) {
+			console.log(e);
+			setStatus("error");
+		}
+	};
 
+	// Fetch data from the database via get request
+	const fetchContentType = async () => {
+		try {
+			const { data } = await axiosInstance.get(
+				`/content-manager/collection-types/${contentTypePath}?sort=rank:asc&page=${currentPage}&pageSize=${pageSize}&locale=${locale}`
+			);
+			setStatus("success");
+			setData(data.results);
+			setPagination(data.pagination);
+		} catch (e) {
+			console.log(e);
+			setStatus("error");
+		}
+	};
 
-  // Render the menu
-  const showMenu = () => {
-    const SortableItem = SortableElement(({ value }) => (
-      <MenuItem style={{ zIndex: 10, cursor: 'all-scroll' }} ><Icon height={"0.6rem"} as={Drag} />&nbsp;<span title={value[settings.title]}>{shortenString(value[settings.title])}</span></MenuItem>
-    ));
+	// Update all ranks via put request.
+	const updateContentType = async ({ oldIndex, newIndex }) => {
+		try {
+			// Increase performance by breaking loop after last element having a rank change is updated
+			const sortedList = arrayMoveImmutable(data, oldIndex, newIndex);
+			let rankHasChanged = false;
+			// Iterate over all results and append them to the list
+			for (let i = 0; i < pageSize; i++) {
+				// Only update changed values
+				if (sortedList[i].id != data[i].id) {
+					const newRank =
+						parseInt(pageSize * (currentPage - 1) + i) || 0;
+					// Update rank via put request
+					await axiosInstance.put(
+						`/drag-drop-content-types/sort-update/${sortedList[i].id}`,
+						{
+							contentType: contentTypePath,
+							rank: newRank,
+						}
+					);
+					rankHasChanged = true;
+				} else if (rankHasChanged) {
+					break;
+				}
+			}
 
-    const SortableList = SortableContainer(({ items }) => {
-      return (
-        <ul>
-          {items.map((value, index) => (
-            <SortableItem key={`item-${value.id}`} index={index} value={value} />
-          ))}
-        </ul>
-      );
-    });
-    return (
-      <>
-        <SimpleMenu
-          as={IconButton}
-          icon={<Layer />}
-          onClick={() => { fetchContentType() }}
-        >
-          <SortableList items={data} onSortEnd={updateContentType} />
-        </SimpleMenu>
-      </>
-    )
-  }
+			//set new sorted data (refresh UI list component)
+			setData(sortedList);
+			setStatus("success");
+			afterUpdate(pagination, sortedList);
+		} catch (e) {
+			console.log(e);
+			setStatus("error");
+		}
+	};
 
-  // Fetch settings on page render
-  useEffect(() => {
-    fetchSettings();
-  }, [])
+	// Actions to perform after sorting is successful
+	const afterUpdate = (pagination, newData) => {
+		// Avoid full page reload and only re-render table.
+		refetchEntries();
+		refetchEntriesSucceeded(pagination, newData);
+	};
 
-  // Update view when settings change
-  useEffect(() => {
-    initializeContentType();
-  }, [settings])
+	// Render the menu
+	const showMenu = () => {
+		const SortableItem = SortableElement(({ value }) => (
+			<MenuItem style={{ zIndex: 10, cursor: "all-scroll" }}>
+				<Icon height={"0.6rem"} as={Drag} />
+				&nbsp;
+				<span title={value[settings.title]}>
+					{shortenString(value[settings.title])}
+				</span>
+			</MenuItem>
+		));
 
-  // Get content type from url
-  const paths = window.location.pathname.split('/')
-  const queryParams = new URLSearchParams(window.location.search);
-  const contentTypePath = paths[paths.length - 1]
-  const locale = queryParams.get('plugins[i18n][locale]');
+		const SortableList = SortableContainer(({ items }) => {
+			return (
+				<ul>
+					{items.map((value, index) => (
+						<SortableItem
+							key={`item-${value.id}`}
+							index={index}
+							value={value}
+						/>
+					))}
+				</ul>
+			);
+		});
+		return (
+			<>
+				<SimpleMenu
+					as={IconButton}
+					icon={<Layer />}
+					onClick={() => {
+						fetchContentType();
+					}}
+				>
+					<SortableList items={data} onSortEnd={updateContentType} />
+				</SimpleMenu>
+			</>
+		);
+	};
 
+	// Fetch settings on page render
+	useEffect(() => {
+		fetchSettings();
+	}, []);
 
-  return (
-    <>
-      {showMenu()}
-    </>
-  );
+	// Update view when settings change
+	useEffect(() => {
+		initializeContentType();
+	}, [settings]);
+
+	// Sync entries in sort menu to match current page of ListView when content-manager page changes
+	useEffect(() => {
+		if (params?.page) {
+			const page = parseInt(params.page);
+			const pageSize = parseInt(params.pageSize);
+
+			setCurrentPage(page);
+			setPageSize(pageSize);
+		}
+	}, [params?.page, params?.pageSize]);
+
+	// Get content type from url
+	const paths = window.location.pathname.split("/");
+	const queryParams = new URLSearchParams(window.location.search);
+	const contentTypePath = paths[paths.length - 1];
+	const locale = queryParams.get("plugins[i18n][locale]");
+
+	return <>{showMenu()}</>;
 };
 
 export default SortModal;

--- a/admin/src/utils/useQueryParams.js
+++ b/admin/src/utils/useQueryParams.js
@@ -1,0 +1,20 @@
+import React, { useState, useEffect } from "react";
+
+export function useQueryParams() {
+	const [queryParams, setQueryParams] = useState({});
+
+	useEffect(() => {
+		const queryParams = new Proxy(
+			new URLSearchParams(window.location.search),
+			{
+				get: (searchParams, prop) => searchParams.get(prop),
+			}
+		);
+		setQueryParams(queryParams);
+		return () => {
+			queryParams;
+		};
+	}, [window.location.search]);
+
+	return [queryParams];
+}

--- a/package.json
+++ b/package.json
@@ -1,51 +1,51 @@
 {
-  "name": "@retikolo/drag-drop-content-types",
-  "version": "1.2.1",
-  "description": "This plugin add a drag and droppable list that allows you to sort content type entries.",
-  "strapi": {
-    "name": "drag-drop-content-types",
-    "description": "This plugin add a drag and droppable list that allows you to sort content type entries.",
-    "kind": "plugin",
-    "displayName": "Drag Drop Content Types"
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/plantagoIT/strapi-drag-drop-content-type-plugin"
-  },
-  "peerDependencies": {
-    "@strapi/strapi": "^4.0.0"
-  },
-  "dependencies": {
-    "array-move": "^4.0.0",
-    "react-sortable-hoc": "^2.0.0"
-  },
-  "author": {
-    "name": "Aeneas Meier",
-    "email": "aeneas@retikolo.xyz",
-    "url": "https://rgb.retikolo.xyz"
-  },
-  "maintainers": [
-    {
-      "name": "Aeneas Meier",
-      "email": "aeneas@retikolo.xyz",
-      "url": "https://rgb.retikolo.xyz"
-    }
-  ],
-  "keywords": [
-    "strapi",
-    "plugin",
-    "strapi-plugin",
-    "drag",
-    "drop",
-    "drag and drop",
-    "drag drop content types",
-    "content types",
-    "sort",
-    "order"
-  ],
-  "engines": {
-    "node": ">=14.19.1 <=18.x.x",
-    "npm": ">=6.0.0"
-  },
-  "license": "MIT"
+	"name": "@retikolo/drag-drop-content-types",
+	"version": "1.2.1",
+	"description": "This plugin add a drag and droppable list that allows you to sort content type entries.",
+	"strapi": {
+		"name": "drag-drop-content-types",
+		"description": "This plugin add a drag and droppable list that allows you to sort content type entries.",
+		"kind": "plugin",
+		"displayName": "Drag Drop Content Types"
+	},
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/plantagoIT/strapi-drag-drop-content-type-plugin"
+	},
+	"peerDependencies": {
+		"@strapi/strapi": "^4.5.4"
+	},
+	"dependencies": {
+		"array-move": "^4.0.0",
+		"react-sortable-hoc": "^2.0.0"
+	},
+	"author": {
+		"name": "Aeneas Meier",
+		"email": "aeneas@retikolo.xyz",
+		"url": "https://rgb.retikolo.xyz"
+	},
+	"maintainers": [
+		{
+			"name": "Aeneas Meier",
+			"email": "aeneas@retikolo.xyz",
+			"url": "https://rgb.retikolo.xyz"
+		}
+	],
+	"keywords": [
+		"strapi",
+		"plugin",
+		"strapi-plugin",
+		"drag",
+		"drop",
+		"drag and drop",
+		"drag drop content types",
+		"content types",
+		"sort",
+		"order"
+	],
+	"engines": {
+		"node": ">=14.19.1 <=18.x.x",
+		"npm": ">=6.0.0"
+	},
+	"license": "MIT"
 }


### PR DESCRIPTION
Solves https://github.com/plantagoIT/strapi-drag-drop-content-type-plugin/issues/3

## Main Features:
- Re-renders the ListView component immediately after sort operation is successful, without reloading the whole page.
- Pagination of the Sorting UI follows that of the ListView component.

## Main Changes:
- Hook into Strapi's existing global state management store for the ListView component, via `react-redux`'s `dispatch` method (This is already being used by `strapi-core`.
- Track and sync state for the current ListView's page/pageSize with the sorting UI modal via `useState` and `useEffect`

## Minor Changes:
- Refactor url query params parsing into hook in `utils/useQueryParams`

## Assumptions:
- All entries already have a `rank` assigned.
- There are no entries with a null `rank`

## Related Future Work:
- Feat: Sort entries across page boundaries