### PR TITLE
Use default content-type Entry title as `title`

### DIFF
--- a/admin/src/components/SortModal/index.js
+++ b/admin/src/components/SortModal/index.js
@@ -73,7 +73,6 @@ const SortModal = () => {
 
 	// Fetch page entries from the sort controller
 	const getPageEntries = async () => {
-		console.log("PAGIN",currentPage == 1, noEntriesFromNextPage,  pageSize, pageSize + noEntriesFromNextPage,  pageSize + 2 * noEntriesFromNextPage, )
 		return await axiosInstance.post(
 			`/drag-drop-content-types/sort-index`,
 			{
@@ -196,7 +195,6 @@ const SortModal = () => {
 		));
 
 		const SortableList = SortableContainer(({ items }) => {
-			console.log(noEntriesFromNextPage , listIncrementSize, data.length);
 			return (
 				<div style={{ maxWidth: "280px" }}>
 					<ul>

--- a/admin/src/components/SortModal/index.js
+++ b/admin/src/components/SortModal/index.js
@@ -12,17 +12,15 @@ import { Icon } from "@strapi/design-system/Icon";
 import Drag from "@strapi/icons/Drag";
 import Layer from "@strapi/icons/Layer";
 
-const DEFAULT_SORT_MENU_PAGE_SIZE = 10;
-const DEFAULT_NUMBER_OF_ENTRIES_FROM_NEXT_PAGE = 3;
-
 const SortModal = () => {
 	const [data, setData] = useState([]);
 	const [currentPage, setCurrentPage] = useState(1);
-	const [pageSize, setPageSize] = useState(DEFAULT_SORT_MENU_PAGE_SIZE);
+	const [pageSize, setPageSize] = useState();
 	const [pagination, setPagination] = useState();
 	const [status, setStatus] = useState("loading");
+	const [mainField, setMainField] = useState('id');
 	const [settings, setSettings] = useState();
-	const [noEntriesFromNextPage, setNoEntriesFromNextPage] = useState(DEFAULT_NUMBER_OF_ENTRIES_FROM_NEXT_PAGE);
+	const [noEntriesFromNextPage, setNoEntriesFromNextPage] = useState();
 
 	// TODO: Refactor get queryParams to hook
 	const [params] = useQueryParams();
@@ -42,13 +40,32 @@ const SortModal = () => {
 		[dispatch, pagination, data]
 	);
 
+	// Fetch content type config settings
+	const fetchContentTypeConfig = async () => {
+		// TODO: tie this in with middleware with the request that is already being made on page load
+		try {
+			const { data } = await axiosInstance.get(
+				`/content-manager/content-types/${contentTypePath}/configuration`
+			);
+			setMainField(data.data.contentType.settings.mainField);
+			setPageSize(data.data.contentType.settings.pageSize);
+			setNoEntriesFromNextPage(data.data.contentType.settings.pageSize / 2);
+		} catch (e) {
+			console.log(e);
+		}
+	};
+
 	// Fetch settings from configuration
 	const fetchSettings = async () => {
 		try {
 			const { data } = await axiosInstance.get(
 				`/drag-drop-content-types/settings`
 			);
-			setSettings(data.body);
+			let fetchedSettings = {
+				rank: data.body.rank,
+				title: data.body.title.length > 0 ? data.body.title : mainField
+			}
+			setSettings(fetchedSettings);
 		} catch (e) {
 			console.log(e);
 		}
@@ -56,10 +73,12 @@ const SortModal = () => {
 
 	// Fetch page entries from the sort controller
 	const getPageEntries = async () => {
+		console.log("PAGIN",currentPage == 1, noEntriesFromNextPage,  pageSize, pageSize + noEntriesFromNextPage,  pageSize + 2 * noEntriesFromNextPage, )
 		return await axiosInstance.post(
 			`/drag-drop-content-types/sort-index`,
 			{
 				contentType: contentTypePath,
+				rankFieldName: settings.rank,
 				start: Math.max(0, (currentPage - 1) * pageSize - noEntriesFromNextPage),
 				limit: currentPage == 1 ? pageSize + noEntriesFromNextPage : pageSize + 2 * noEntriesFromNextPage,
 				locale: locale,
@@ -75,8 +94,7 @@ const SortModal = () => {
 				const entries = await getPageEntries()
 				if (
 					entries.data.length > 0 &&
-					!!toString(entries.data[0][settings.rank]) &&
-					!!entries.data[0][settings.title]
+					!!toString(entries.data[0][settings.rank])
 				) {
 					setStatus("success");
 				}
@@ -119,6 +137,7 @@ const SortModal = () => {
 						`/drag-drop-content-types/sort-update/${sortedList[i].id}`,
 						{
 							contentType: contentTypePath,
+							rankFieldName: settings.rank,
 							rank: newRank,
 						}
 					);
@@ -177,6 +196,7 @@ const SortModal = () => {
 		));
 
 		const SortableList = SortableContainer(({ items }) => {
+			console.log(noEntriesFromNextPage , listIncrementSize, data.length);
 			return (
 				<div style={{ maxWidth: "280px" }}>
 					<ul>
@@ -192,7 +212,7 @@ const SortModal = () => {
 					<Divider unsetMargin={false} />
 					<Button
 						size="S"
-						disabled={noEntriesFromNextPage + listIncrementSize >= data.length ? true : false}
+						disabled={noEntriesFromNextPage + listIncrementSize >= data.length - 1 ? true : false}
 						onClick={() => { setNoEntriesFromNextPage(noEntriesFromNextPage + listIncrementSize) }}
 					>Show more</Button>
 				</div>
@@ -217,10 +237,15 @@ const SortModal = () => {
 		);
 	};
 
+	// Fetch content-type on page render
+	useEffect(() => {
+		fetchContentTypeConfig();
+	}, []);
+
 	// Fetch settings on page render
 	useEffect(() => {
 		fetchSettings();
-	}, []);
+	}, [mainField]);
 
 	// Update view when settings change
 	useEffect(() => {
@@ -229,7 +254,9 @@ const SortModal = () => {
 
 	// Update menu when loading more elements
 	useEffect(() => {
-		fetchContentType();
+		if (settings){
+			fetchContentType();
+		}
 	}, [noEntriesFromNextPage])
 
 	// Sync entries in sort menu to match current page of ListView when content-manager page changes

--- a/admin/src/pages/Settings/index.js
+++ b/admin/src/pages/Settings/index.js
@@ -111,7 +111,7 @@ const Settings = () => {
                     <TextInput
                       placeholder="Title"
                       label="Title Field Name"
-                      hint="You must create a Short Text Field with this label in the Content-Type Builder"
+                      hint="Select or create a Short Text Field with this label in the Content-Type Builder. Leave blank to use content-type entry title"
                       name="content"
                       onChange={e => {
                         setSettings({


### PR DESCRIPTION
Send axios get request to the current content type configuration to get the needed data to make things suited for all content-type rather than add in a global setting and or static vars.