### PR TITLE
Handle rank field error

### DIFF
--- a/admin/src/components/SortModal/index.js
+++ b/admin/src/components/SortModal/index.js
@@ -231,7 +231,9 @@ const SortModal = () => {
 
 	// Update menu when loading more elements
 	useEffect(() => {
-		fetchContentType();
+		if (settings){
+			fetchContentType();
+		}
 	}, [noEntriesFromNextPage])
 
 	// Sync entries in sort menu to match current page of ListView when content-manager page changes

--- a/admin/src/components/SortModal/index.js
+++ b/admin/src/components/SortModal/index.js
@@ -60,6 +60,7 @@ const SortModal = () => {
 			`/drag-drop-content-types/sort-index`,
 			{
 				contentType: contentTypePath,
+				rankFieldName: settings.rank,
 				start: Math.max(0, (currentPage - 1) * pageSize - noEntriesFromNextPage),
 				limit: currentPage == 1 ? pageSize + noEntriesFromNextPage : pageSize + 2 * noEntriesFromNextPage,
 				locale: locale,
@@ -119,6 +120,7 @@ const SortModal = () => {
 						`/drag-drop-content-types/sort-update/${sortedList[i].id}`,
 						{
 							contentType: contentTypePath,
+							rankFieldName: settings.rank,
 							rank: newRank,
 						}
 					);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@retikolo/drag-drop-content-types",
-	"version": "1.3.3",
+	"version": "1.3.4",
 	"description": "This plugin add a drag and droppable list that allows you to sort content type entries.",
 	"strapi": {
 		"name": "drag-drop-content-types",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@retikolo/drag-drop-content-types",
-	"version": "1.3.2",
+	"version": "1.3.3",
 	"description": "This plugin add a drag and droppable list that allows you to sort content type entries.",
 	"strapi": {
 		"name": "drag-drop-content-types",

--- a/server/controllers/sort.js
+++ b/server/controllers/sort.js
@@ -13,7 +13,7 @@ function getPluginStore() {
 async function createDefaultConfig() {
   const pluginStore = getPluginStore();
   const value = {
-    body:{
+    body: {
       rank: 'rank',
       title: 'title',
     }
@@ -41,26 +41,26 @@ async function setSettings(settings) {
 }
 
 // Search for entries ordered by rank
-async function index(contentType, start, limit, locale) {
-  return await strapi.entityService.findMany(contentType, {
-    sort: {
-      rank: 'asc'
-    },
+async function index(contentType, start, limit, locale, rankFieldName) {
+  let indexData = {
+    sort: { },
     populate: '*',
     start: start,
     limit: limit,
     locale: locale,
-  });
+  }
+  indexData.sort[rankFieldName] = 'asc'
+  return await strapi.entityService.findMany(contentType, indexData );
 }
 
 // Update rank of specified content type
-async function update(id, contentType, rank) {
-  return await strapi.query(contentType).update({
+async function update(id, contentType, rank, rankFieldName) {
+  let updateData = {
     where: { id: id },
-    data: {
-      rank: rank,
-    }
-  });
+    data: {}
+  }
+  updateData.data[rankFieldName] = rank;
+  return await strapi.query(contentType).update(updateData);
 }
 
 module.exports = {
@@ -82,14 +82,14 @@ module.exports = {
   },
   async index(ctx) {
     try {
-      ctx.body = await index(ctx.request.body.contentType, ctx.request.body.start, ctx.request.body.limit, ctx.request.body.locale);
+      ctx.body = await index(ctx.request.body.contentType, ctx.request.body.start, ctx.request.body.limit, ctx.request.body.locale, ctx.request.body.rankFieldName);
     } catch (err) {
       ctx.throw(500, err);
     }
   },
   async update(ctx) {
     try {
-      ctx.body = await update(ctx.params.id, ctx.request.body.contentType, ctx.request.body.rank);
+      ctx.body = await update(ctx.params.id, ctx.request.body.contentType, ctx.request.body.rank, ctx.request.body.rankFieldName);
     } catch (err) {
       ctx.throw(500, err);
     }

--- a/server/controllers/sort.js
+++ b/server/controllers/sort.js
@@ -50,7 +50,13 @@ async function index(contentType, start, limit, locale, rankFieldName) {
     locale: locale,
   }
   indexData.sort[rankFieldName] = 'asc'
-  return await strapi.entityService.findMany(contentType, indexData );
+  let indexResult
+  try {
+    indexResult = await strapi.entityService.findMany(contentType, indexData );
+  } catch(e) {
+    // likely no rank field, so don't use plugin for this content-type
+  }
+  return indexResult;
 }
 
 // Update rank of specified content type


### PR DESCRIPTION
This pull request fixes an error when opening the content manager for a content type that does not have a rank field:
```
Error: Attribute rank not found on model api::xxx.xxx
    at /Users/xxx/projects/xxx/node_modules/@strapi/database/lib/query/helpers/order-by.js:36:15
    at Array.flatMap (<anonymous>)
    at Object.processOrderBy (/Users/xxx/projects/xxx/node_modules/@strapi/database/lib/query/helpers/order-by.js:31:36)
    at Object.processState (/Users/xxx/projects/xxx/node_modules/@strapi/database/lib/query/query-builder.js:303:31)
    at Object.getKnexQuery (/Users/xxx/projects/xxx/node_modules/@strapi/database/lib/query/query-builder.js:354:12)
    at Object.execute (/Users/xxx/projects/xxx/node_modules/@strapi/database/lib/query/query-builder.js:475:25)
    at Object.findMany (/Users/xxx/projects/xxx/node_modules/@strapi/database/lib/entity-manager/index.js:189:70)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async index (/Users/xxx/projects/xxx/node_modules/@retikolo/drag-drop-content-types/server/controllers/sort.js:53:10)
    at async Object.index (/Users/xxx/projects/xxx/node_modules/@retikolo/drag-drop-content-types/server/controllers/sort.js:85:18)
```
Fixes #25, which apparently is not the same issue as #26.