### PR TITLE
Add fallback title field

### DIFF
--- a/admin/src/components/SortModal/index.js
+++ b/admin/src/components/SortModal/index.js
@@ -77,7 +77,7 @@ const SortModal = () => {
 				if (
 					entries.data.length > 0 &&
 					!!toString(entries.data[0][settings.rank]) &&
-					!!entries.data[0][settings.title]
+					(!!entries.data[0][settings.title] || !!entries.data[0][settings.fallbackTitle] )
 				) {
 					setStatus("success");
 				}
@@ -171,8 +171,8 @@ const SortModal = () => {
 				>
 					<Icon height={"0.6em"} as={Drag} />
 					&nbsp;
-					<span title={value[settings.title]}>
-						{value[settings.title]}
+					<span title={value[settings.title] || value[settings.fallbackTitle]}>
+						{value[settings.title] || value[settings.fallbackTitle]}
 					</span>
 				</div>
 			</MenuItem>

--- a/admin/src/pages/Settings/index.js
+++ b/admin/src/pages/Settings/index.js
@@ -133,6 +133,33 @@ const Settings = () => {
                       } />
                   </Box>
                 </GridItem>
+                <GridItem col={6} s={12}>
+                  <Box padding={0}>
+                    <TextInput
+                      placeholder="Fallback Title"
+                      label="Fallback Title Field Name"
+                      hint="You must create a Short Text Field with the main title label or the fallback label in the Content-Type Builder"
+                      name="content"
+                      onChange={e => {
+                        setSettings({
+                          ...settings,
+                          fallbackTitle: e.target.value,
+                        })
+                      }}
+                      value={settings.fallbackTitle}
+                      labelAction={
+                        <Tooltip description="Fallback title Field that will show up in the drag drop menu">
+                          <button aria-label="Information about the email" style={{
+                            border: 'none',
+                            padding: 0,
+                            background: 'transparent'
+                          }}>
+                            <Information aria-hidden={true} />
+                          </button>
+                        </Tooltip>
+                      } />
+                  </Box>
+                </GridItem>
               </Grid>
             </Stack>
           </Box>

--- a/server/controllers/sort.js
+++ b/server/controllers/sort.js
@@ -16,6 +16,7 @@ async function createDefaultConfig() {
     body: {
       rank: 'rank',
       title: 'title',
+      fallbackTitle: 'name'
     }
   };
   await pluginStore.set({ key: 'settings', value });


### PR DESCRIPTION
Fallback Title field (defaults to "name") so you can support ordering without a breaking change to your api.
In our case we had to change collections to have a "title" field instead of "name" which would mean changes across several apps and clients.