### PR TITLE
[Fix] make it possible to actually be able to change rank field name

### DIFF
--- a/admin/src/components/SortModal/index.js
+++ b/admin/src/components/SortModal/index.js
@@ -95,7 +95,7 @@ const SortModal = () => {
 			setStatus("success");
 			setData(entries.data);
 			// TODO: remove this line and get pagination from elsewhere
-			const { data } = await axiosInstance.get(`/content-manager/collection-types/${contentTypePath}?sort=rank:asc&page=${currentPage}&pageSize=${pageSize}&locale=${locale}`);
+			const { data } = await axiosInstance.get(`/content-manager/collection-types/${contentTypePath}?sort=${settings.rank}:asc&page=${currentPage}&pageSize=${pageSize}&locale=${locale}`);
 			setPagination(data.pagination);
 		} catch (e) {
 			console.log(e);


### PR DESCRIPTION
## Fixed
In the `fetchContentType()` function there was the `rank` field name hardcoded in the API request. It made it impossible to actually change the rank field name - when it was changed in config, clicking on the sort button resulted in internal server error, because "rank field does not exist".
I changed the hardcoded `?sort=rank:asc` to `?sort=${settings.rank}:asc` and it works with custom field names now :)

Fixes #32 