### PR TITLE
:bug: Update SimpleMenu to use onOpen instead of onClick

### DIFF
--- a/admin/src/components/SortModal/index.js
+++ b/admin/src/components/SortModal/index.js
@@ -224,7 +224,7 @@ const SortModal = () => {
 						as={IconButton}
 						icon={<Layer />}
 						label="Sort via drag and drop"
-						onClick={() => {
+						onOpen={() => {
 							fetchContentType();
 						}}
 					>


### PR DESCRIPTION
https://github.com/plantagoIT/strapi-drag-drop-content-type-plugin/issues/42#issuecomment-1591860148
Thanks @brian-vanlerberghe !