### PR TITLE
fix: do not import actions from strapi admin (#58)

### DIFF
--- a/admin/src/components/SortModal/index.js
+++ b/admin/src/components/SortModal/index.js
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from "react";
 import { useDispatch } from "react-redux";
-import { getData, getDataSucceeded } from "@strapi/admin/admin/src/content-manager/pages/ListView/actions";
+import { getData, getDataSucceeded } from "../../utils/strapi";
 import axiosInstance from "../../utils/axiosInstance";
 import { SortableContainer, SortableElement } from "react-sortable-hoc";
 import { arrayMoveImmutable } from "array-move";

--- a/admin/src/utils/strapi.js
+++ b/admin/src/utils/strapi.js
@@ -1,0 +1,18 @@
+export const GET_DATA = 'ContentManager/ListView/GET_DATA';
+export const GET_DATA_SUCCEEDED = 'ContentManager/ListView/GET_DATA_SUCCEEDED';
+
+export function getData(uid, params) {
+  return {
+    type: GET_DATA,
+    uid,
+    params,
+  };
+}
+
+export function getDataSucceeded(count, data) {
+  return {
+    type: GET_DATA_SUCCEEDED,
+    count,
+    data,
+  };
+}


### PR DESCRIPTION
Since we cannot import anything from strapi/admin right now the only way to fix this issue is to migrate the two methods into plugin code. 

This change fixes the issues with latest strapi version 4.15.4

Related issue #58 