### PR TITLE
build(strapi-icons): allow other package versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
       },
       "peerDependencies": {
         "@strapi/design-system": "^1.13.1",
-        "@strapi/icons": "1.13.1",
+        "@strapi/icons": "^1.13.1",
         "@strapi/strapi": "^4.0.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "peerDependencies": {
     "@strapi/design-system": "^1.13.1",
-    "@strapi/icons": "1.13.1",
+    "@strapi/icons": "^1.13.1",
     "@strapi/strapi": "^4.0.0"
   },
   "author": {


### PR DESCRIPTION
Hi,

With the current syntax for the strapi-icons package and the newer strapi versions (4.17) which uses strapi-icons 1.14, a dependency conflict will be generated. This quick fix will solve that.

Thank you for this plugin!
Cheers