### PR TITLE
fix: main field not being used as fallback

### DIFF
--- a/admin/src/components/SortModal/index.js
+++ b/admin/src/components/SortModal/index.js
@@ -77,6 +77,7 @@ const SortModal = () => {
         rank: data.body.rank,
         title: data.body.title?.length > 0 ? data.body.title : mainField,
         subtitle: data.body.subtitle?.length > 0 ? data.body.subtitle : null,
+        mainField,
       };
       setSettings(fetchedSettings);
     } catch (e) {
@@ -212,10 +213,10 @@ const SortModal = () => {
     fetchContentTypeConfig();
   }, []);
 
-  // Fetch settings on page render
+  // Fetch settings when mainField changes
   useEffect(() => {
     fetchSettings();
-  }, []);
+  }, [mainField]);
 
   // Update view when settings change
   useEffect(() => {


### PR DESCRIPTION
Fixes #68 
Related #2 

## Problem

If the user doesn't specify any custom title field in the plugin configuration page, then the default fallback should be `mainField` (i.e. the collection's Entry title).

However it is currently falling back to `id` instead.


## Why

`mainField` is always `id`, because the `setMainField(settings.mainField)` never triggers a state update through `fetchSettings`, due to missing lifecycle dependency.

## Fix

- Trigger settings to update when `mainField` gets changed
- Include `mainField` in the `settings` object - as it is expected by the function `getTitle()` in `SortableList`

## How to test

1. Make sure `Title Field Name` is empty in plugin configuration page
2. Configure the Entry title field for a collection type
3. Check on the listing page it is correctly using the Entry title field as display
4. Repeat step 2 & 3, trying different fields on the collection