### PR TITLE
CI: Run tests and fix package.json scripts

### DIFF
--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -1,0 +1,44 @@
+name: Typecheck
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  typecheck-server:
+    name: Server types (Node ${{ matrix.node-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [18, 20, 22]
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: ${{ matrix.node-version }}
+          package-manager-cache: false # Explicitly disable caching if you don't have a lockfile
+
+      - run: npm install
+
+      - name: Check server types
+        run: npm run test:ts:back
+
+  typecheck-admin:
+    name: Admin types (Node ${{ matrix.node-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [18, 20, 22]
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: ${{ matrix.node-version }}
+          package-manager-cache: false # Explicitly disable caching if you don't have a lockfile
+
+      - run: npm install
+
+      - name: Check admin types
+        run: npm run test:ts:front

--- a/package.json
+++ b/package.json
@@ -46,8 +46,8 @@
   ],
   "scripts": {
     "build": "strapi-plugin build",
-    "test:ts:back": "run -T tsc -p server/tsconfig.json",
-    "test:ts:front": "run -T tsc -p admin/tsconfig.json",
+    "test:ts:back": "tsc -p server/tsconfig.json",
+    "test:ts:front": "tsc -p admin/tsconfig.json",
     "verify": "strapi-plugin verify",
     "watch": "strapi-plugin watch",
     "watch:link": "strapi-plugin watch:link"


### PR DESCRIPTION
`run -T` is short for Yarn v2 `--top-level`.
Remove `run -T`, because the project should be self-contained.

This is without creating a lock file. It would also be sensible to create a lock file, as best practice recommends.